### PR TITLE
Make server version and logs required

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,6 +56,8 @@ body:
         
         Example:
         This server is running Paper version git-Paper-788 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)"
+    validations:
+      required: true
   - type: textarea
     id: plugin_version
     attributes:
@@ -123,6 +125,8 @@ body:
             at com.comphenix.protocol.reflect.FieldUtils.getField(FieldUtils.java:111) ~[PROTOCOLLIB.jar:?]
             at dev.lone.itemsadder.l.k.<clinit>(SourceFile:12) ~[ItemsAdder.jar:?]
             ... 9 more
+    validations:
+      required: true
   - type: textarea
     id: configuration_item
     attributes:


### PR DESCRIPTION
There isn't really any reason why these fields shouldn't be mandatory to be filled out.

Also, I personally propose to not have a text area with code rendering for logs, but an input field where you post a paste URL, as this will make reading issues significantly easier with larger logs.
I haven't made these changes in this PR tho, but can make them if considered.