### PR TITLE
Create Workflow to close and label issues on "Duplicate of" text

### DIFF
--- a/.github/workflows/close_duplicates.yml
+++ b/.github/workflows/close_duplicates.yml
@@ -1,0 +1,29 @@
+name: Close duplicate issue
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  close_issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, 'Duplicate of') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') }}
+    steps:
+      - name: Apply Labels
+        run: 'gh issue edit "$NUMBER" --add-label "type: duplicate" --remove-label "type: bug"'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+      - name: Close issue
+        run: 'gh issue close "$NUMBER" --reason "not planned"'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -18,7 +18,12 @@ jobs:
     permissions:
       issues: write
     # Check that the comment is on an issue, contains "Duplicate of" and that author is owner, member or collaborator.
-    if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, 'Duplicate of') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') }}
+    if: |-
+      ${{
+        !github.event.issue.pull_request &&
+        contains(github.event.comment.body, 'Duplicate of') &&
+        (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
+      }}
     steps:
       # Add "type: duplicate" label and remove "type: bug" label.
       - name: Update Issue Labels

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -1,8 +1,13 @@
-name: Close duplicate issue
+# This is a GitHub Action Workflow designed to execute specific actions based on specific comments.
+# As of right now is this Workflow supporting the following:
+#   - Close issues and label them as "type: duplicate" when owner/member/collaborator writes "Duplicate of"
+name: Issue Comment Actions
 on:
   issue_comment:
     types: [created]
 
+# Ensures that only one action runs per issue, preventing possible race-conditions or smth.
+# Any other action for the same issue should be put in queue, waiting for the active one to finish.
 concurrency:
   group: ${{ github.event.issue.number }}
   cancel-in-progress: false
@@ -12,14 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    # Check that the comment is on an issue, contains "Duplicate of" and that author is owner, member or collaborator.
     if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, 'Duplicate of') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') }}
     steps:
-      - name: Apply Labels
+      # Add "type: duplicate" label and remove "type: bug" label.
+      - name: Update Issue Labels
         run: 'gh issue edit "$NUMBER" --add-label "type: duplicate" --remove-label "type: bug"'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
+      # Close issue as "Not Planned"
       - name: Close issue
         run: 'gh issue close "$NUMBER" --reason "not planned"'
         env:

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -25,9 +25,9 @@ jobs:
         (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
       }}
     steps:
-      # Add "type: duplicate" label and remove "type: bug" label.
+      # Add "type: duplicate" label
       - name: Update Issue Labels
-        run: 'gh issue edit "$NUMBER" --add-label "type: duplicate" --remove-label "type: bug"'
+        run: 'gh issue edit "$NUMBER" --add-label "type: duplicate"'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
LoneDev asked me if I could look into making a Workflow that would automatically close and label issues when he or a member/collaborator is commenting with "Duplicate of ..." text on an issue.

This is the result of this request.

Basic testing done [here](https://github.com/Andre601/Issues-ItemsAdder/issues/1) shows it working. Tho, I would apreciate if people can comment on it with "Duplicate of" to see if the action is actually triggering and closing it.

I'll leave this PR a draft until some further testing was done.