### PR TITLE
Make the action remove all labels.

### DIFF
--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # Add "type: duplicate" label
       - name: Update Issue Labels
-        run: 'gh issue edit "$NUMBER" --add-label "type: duplicate"'
+        run: 'gh issue edit $NUMBER --add-label "type: duplicate" --remove-label "$(gh issue view $NUMBER --json labels --jq ''.labels | map(.name) | join(",")'')"'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
The action is now able to remove all labels an issue has right now while adding the duplicate one.

However, there is currently the small issue that if the issue already has the duplicate label added, that it will remove it too, as it effectively goes through all labels an issue has right now to remove.

Tho, given this should only be used on issues not yet marked a duplicate, we can probably ignore this.