### PR TITLE
Add action step to edit comment

### DIFF
--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -48,9 +48,7 @@ jobs:
             <!-- Bot comment Start -->
             ----
             
-            Please always check the issue tracker for pre-existing issues (including closed ones) before creating a new issue. Thanks!
-
-            > [!NOTE]  
-            > Comment edited by GitHub Actions.
+            Your issue has been marked as **duplicate**!
+            Please always check the issue tracker first for any existing issues of the same problem/suggestion (including closed ones!) before creating your own. Thank you.
           edit-mode: append
         

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -43,7 +43,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.issue.number }}
-          coment-id: ${{ github.event.comment.id }}
+          comment-id: ${{ github.event.comment.id }}
           body: |-
             ----
             

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -45,6 +45,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           body: |-
+            
             ----
             
             Please always check the issue tracker for pre-existing issues (including closed ones) before creating a new issue. Thanks!

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -45,7 +45,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           body: |-
-            
+            <!-- Bot comment Start -->
             ----
             
             Please always check the issue tracker for pre-existing issues (including closed ones) before creating a new issue. Thanks!

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -21,6 +21,7 @@ jobs:
     if: |-
       ${{
         !github.event.issue.pull_request &&
+        github.event.issue.state == 'open' &&
         contains(github.event.comment.body, 'Duplicate of') &&
         (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
       }}

--- a/.github/workflows/issue_comment_actions.yml
+++ b/.github/workflows/issue_comment_actions.yml
@@ -39,4 +39,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
+      - name: Update Comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          coment-id: ${{ github.event.comment.id }}
+          body: |-
+            ----
+            
+            Please always check the issue tracker for pre-existing issues (including closed ones) before creating a new issue. Thanks!
+
+            > [!NOTE]  
+            > Comment edited by GitHub Actions.
+          edit-mode: append
         


### PR DESCRIPTION
Adds another step to the duplicate issue action to edit the comment of the "Duplicate of" writer, to append the note of their issue being marked as duplicate.

It also adds a check to only handle open issues.